### PR TITLE
list_basic_4_2

### DIFF
--- a/HTML_HTTP/list/list_4_2.css
+++ b/HTML_HTTP/list/list_4_2.css
@@ -1,0 +1,3 @@
+.list {
+  background-color: lightpink;
+}

--- a/HTML_HTTP/list/list_4_2.html
+++ b/HTML_HTTP/list/list_4_2.html
@@ -1,0 +1,22 @@
+<!-- 参照：HTML Tag Board -->
+<!-- 2 番号付きのリストの開始番号を指定する
+ol start=”” li
+olタグに「start=””」という属性を追加すると、
+グループごとにこの開始番号を変更することができる  -->
+
+
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="list_4_2.css">
+  <title>ListTraining_4_2</title>
+</head>
+<body>
+  <ol start="7">
+    <li>olタグに「start=””」で開始番号を変更できる（指定なしの場合は本来は「1」）</li>
+    <li class="list">指定なしの場合は本来は「2」</li>
+  </ol>
+  
+</body>
+</html>


### PR DESCRIPTION
### HTML_listの基礎_4_2について

- 2 番号付きのリストの開始番号を指定する
- ol start=”” li
olタグに「start=””」という属性を追加すると、
グループごとにこの開始番号を変更することができる

- 参照：HTML Tag Board