### PR TITLE
list_basic_4_3

### DIFF
--- a/HTML_HTTP/list/list_4_3.css
+++ b/HTML_HTTP/list/list_4_3.css
@@ -1,0 +1,6 @@
+.container {
+  background-color: bisque;
+}
+.first_text {
+  color: coral;
+}

--- a/HTML_HTTP/list/list_4_3.html
+++ b/HTML_HTTP/list/list_4_3.html
@@ -1,0 +1,40 @@
+<!-- 参照：HTML Tag Board -->
+<!-- 3 番号付きのリストマークをリストごとに変える
+ol li type=”” 
+番号付きリストで書かれた文章の文頭には、
+標準では「1.」→「2.」…のように数字が表示されますが、
+olタグ内のliタグに「type=””」という属性を追加すると、
+リストごとに、それぞれ文章の文頭に書かれる表記の種類を変更することができる。 -->
+
+<!-- 3.1 
+type=”1”
+数字（1.2.3.…）
+type=”I”
+大文字のローマ数字（I.II.III…）
+type=”i”
+小文字のローマ数字（i.ii.iii…）
+type=”A”
+大文字の英字（A.B.C.…）
+type=”a”
+小文字の英字（a.b.c.） -->
+
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="list_4_3.css">
+  <title>ListTraining_4_3</title>
+</head>
+<body>
+  <div class="container">
+    <ol type="A">
+      <li class="first_text">朝起きる</li>
+      <li>顔洗う</li>
+      <li>歯を磨く</li>
+      <li>コップ一杯の常温水を一気に飲む</li>
+      <li>約10分ストレッチする</li>
+      <li>朝活開始</li>
+    </ol>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
### HTML_listの基礎_4_3について

- 3 番号付きのリストマークをリストごとに変える
- ol li type=”” 
番号付きリストで書かれた文章の文頭には、
標準では「1.」→「2.」…のように数字が表示されますが、
olタグ内のliタグに「type=””」という属性を追加すると、
リストごとに、それぞれ文章の文頭に書かれる表記の種類を変更することができる
- 3.1 typeの種類
（1）type=”1”
数字（1.2.3.…）
（2）type=”I”
大文字のローマ数字（I.II.III…）
（3）type=”i”
小文字のローマ数字（i.ii.iii…）
（4）type=”A”
大文字の英字（A.B.C.…）
（5）type=”a”
小文字の英字（a.b.c.）

- 参照：HTML Tag Board