### PR TITLE
list_basic_4_4

### DIFF
--- a/HTML_HTTP/list/list_4_3.html
+++ b/HTML_HTTP/list/list_4_3.html
@@ -7,15 +7,15 @@ olタグ内のliタグに「type=””」という属性を追加すると、
 リストごとに、それぞれ文章の文頭に書かれる表記の種類を変更することができる。 -->
 
 <!-- 3.1 
-type=”1”
+type="1"
 数字（1.2.3.…）
-type=”I”
+type="I"
 大文字のローマ数字（I.II.III…）
-type=”i”
+type="i"
 小文字のローマ数字（i.ii.iii…）
-type=”A”
+type="A"
 大文字の英字（A.B.C.…）
-type=”a”
+type="a"
 小文字の英字（a.b.c.） -->
 
 <!DOCTYPE html>
@@ -27,12 +27,12 @@ type=”a”
 </head>
 <body>
   <div class="container">
-    <ol type="A">
+    <ol>
       <li class="first_text">朝起きる</li>
-      <li>顔洗う</li>
-      <li>歯を磨く</li>
-      <li>コップ一杯の常温水を一気に飲む</li>
-      <li>約10分ストレッチする</li>
+      <li type="A">顔洗う</li>
+      <li type="I">歯を磨く</li>
+      <li type="i">コップ一杯の常温水を一気に飲む</li>
+      <li type="a">約10分ストレッチする</li>
       <li>朝活開始</li>
     </ol>
   </div>

--- a/HTML_HTTP/list/list_4_4.css
+++ b/HTML_HTTP/list/list_4_4.css
@@ -1,0 +1,7 @@
+.container {
+  background-color: cornsilk;
+}
+
+.list_text {
+  color: aqua;
+}

--- a/HTML_HTTP/list/list_4_4.html
+++ b/HTML_HTTP/list/list_4_4.html
@@ -1,0 +1,38 @@
+<!-- 参照：HTML Tag Board -->
+<!-- 1 番号付きのリストのマークをグループごとに変更する
+ol type=””  li
+番号付きリストで書かれた文章の文頭には、
+標準では「1.」→「2.」…のように数字が表示されますが、
+olタグに「type=””」という属性を追加すると、
+グループごと（olタグ内のliタグすべてに適用）にこの表記方法を変更することができる -->
+
+<!-- 2 記載方法
+type="1"
+数字（1.2.3.…）
+type="I"
+大文字のローマ数字（I.II.III…）
+type="i"
+小文字のローマ数字（i.ii.iii…）
+type="A"
+大文字の英字（A.B.C.…）
+type="a"
+小文字の英字（a.b.c.） -->
+
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="list_4_4.css">
+  <title>ListTraining_4_4</title>
+</head>
+<body>
+  <div class="container">
+    <ol type="A">
+      <li>お米3合とる</li>
+      <li>水で2回ほど洗う（洗いすぎるとお米の栄養も流れちゃうため注意）</li>
+      <li>水を炊飯器の3合ラインまで入れる</li>
+      <li class="list_text">炊飯器で白米で炊く</li>
+    </ol>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
### HTML_listの基礎_4_4について

- 1 番号付きのリストマークをリストごとに変える
- ol type=””  li
番号付きリストで書かれた文章の文頭には、
標準では「1.」→「2.」…のように数字が表示されますが、
olタグに「type=””」という属性を追加すると、
グループごと（olタグ内のliタグすべてに適用）にこの表記方法を変更することができる
- 2 記載方法
type="1"
数字（1.2.3.…）
type="I"
大文字のローマ数字（I.II.III…）
type="i"
小文字のローマ数字（i.ii.iii…）
type="A"
大文字の英字（A.B.C.…）
type="a"
小文字の英字（a.b.c.）

- 参照：HTML Tag Board